### PR TITLE
User modules

### DIFF
--- a/docs/user_modules.md
+++ b/docs/user_modules.md
@@ -25,6 +25,8 @@ local Module = { _version = '1.0', _name = "MyModule", _author = 'YourName', }
 
 `_name` must be unique across every loaded module, RGMercs' own included. If two files claim the same name the first one alphabetically wins; the loser shows a red status in the UserModules tab and refuses to load until you rename it.
 
+`_about` is optional. Supply a sentence describing what your module does and the UserModules tab draws an info icon beside its name carrying that text, which is how anyone else on your machine finds out what it is for.
+
 ## Refresh vs. reload
 
 **Refresh** re-reads the folder and rebuilds the list: new files, deleted files, changed `_name`s, new collisions. It does not touch anything that is already running.
@@ -72,7 +74,7 @@ A standalone slash command like `/mybind` goes through `self:RegisterBind`, whic
 
 Disabling a module clears its settings from memory but leaves them in the database, so re-enabling restores everything the user had configured. The module also keeps its position in the list while disabled.
 
-Deleting the file leaves the row behind, marked "File missing" — the trash button forgets it. The module's own saved settings survive that, and RGMercs' existing database cleanup is the way to remove them.
+Deleting the file drops the module from the list on the next refresh. Its saved settings survive that, and RGMercs' existing database cleanup is the way to remove them.
 
 ## What your module can reach
 

--- a/docs/user_modules.md
+++ b/docs/user_modules.md
@@ -1,0 +1,89 @@
+# User Modules
+
+User modules are Lua files you drop into your own MQ config folder. RGMercs loads them alongside its built-in modules, so they get the same lifecycle hooks, settings storage, UI tab and `/rgl` command dispatch that a shipped module does.
+
+## Getting started
+
+1. RGMercs creates `<MQ config dir>/rgmercs/modules` on first run and puts `hello_world.lua` in it — a working example you can enable straight away to see one running. Copy it to `mymodule.lua` in the same folder to start your own.
+2. Edit `_name` in the file to something unique.
+3. Open the **UserModules** tab in RGMercs and press **Refresh**.
+4. Toggle **Enabled** on your module's row.
+
+Enabled modules reload automatically the next time RGMercs starts. Modules load in the order they appear in that table, and the arrows reorder them.
+
+`/rgl usermodule <name> <on|off>` enables or disables a module from the command line. It locates the file itself, so the tab does not have to have been opened first.
+
+Which modules are enabled is saved per character and per class, the same as the rest of your settings, so a persona swap switches to that class's set — anything no longer enabled is unloaded and anything newly enabled is loaded.
+
+## The identity fields
+
+```lua
+local Module = { _version = '1.0', _name = "MyModule", _author = 'YourName', }
+```
+
+`_name` is the important one. It is simultaneously the tab label, the settings database namespace, and the key used to dispatch calls to your module. Changing it after you have saved settings orphans those settings, so pick it once and leave it alone. The filename itself is free — only `_name` matters.
+
+`_name` must be unique across every loaded module, RGMercs' own included. If two files claim the same name the first one alphabetically wins; the loser shows a red status in the UserModules tab and refuses to load until you rename it.
+
+## Refresh vs. reload
+
+**Refresh** re-reads the folder and rebuilds the list: new files, deleted files, changed `_name`s, new collisions. It does not touch anything that is already running.
+
+**Reload** is unticking and re-ticking Enabled. Because the file is read from disk every time it loads, this is how you pick up your own edits without restarting RGMercs.
+
+One caveat: if your module `require`s a sub-file of its own, edits to that sub-file will not be picked up by a reload — Lua caches it. Restart RGMercs to pick those up.
+
+## Lifecycle hooks
+
+Inherit from `modules.base` and override what you need. Everything below is optional except `New`.
+
+| Hook | When it fires |
+| --- | --- |
+| `New()` | Construction. Return `Base.New(self)`. |
+| `Init()` | Once at load. Call `Base.Init(self)` to load your settings. |
+| `GiveTime()` | Every main loop tick. Keep this cheap. |
+| `Render()` | Every UI frame your tab is visible. |
+| `ShouldRender()` | Gates whether your tab exists at all. |
+| `OnZone()` | After a zone change. |
+| `OnDeath()` | When you die. |
+| `OnCombatModeChanged()` | When RGMercs switches combat mode. |
+| `OnTargetChange(targetId)` | When RGMercs changes your target. |
+| `OnForceTargetChange(forceTargetId)` | When the forced target changes. |
+| `Shutdown()` | On unload. Release in-memory state only. |
+
+## Where things go
+
+- **Settings** go in `Module.DefaultConfig`, keyed by setting name. Define the table even if it is empty — a module without one will not load. Each entry carries `DisplayName`, `Tooltip`, `Default` and friends, and every entry that is not `Type = "Custom"` must also carry a `Category`, which is what the settings UI groups it under.
+
+  Setting names are global across RGMercs, not scoped to your module. If you declare a name another module already owns, your module is refused with an error naming the owner — so prefix your setting names with something distinctive.
+- **Events, binds, actors and ImGui windows** go in `Init()`, registered through `self:RegisterEvent`, `self:RegisterBind`, `self:RegisterActor` and `self:RegisterImGui`. These wrap the equivalent `mq` calls and record what you registered, so unloading your module tears all of it down automatically. Register them any other way and they will survive an unload.
+- **Per-tick work** goes in `GiveTime()`.
+- **Your tab's UI** goes in `Render()`, gated by `ShouldRender()`.
+
+## Commands
+
+Two routes, and you can use both.
+
+A `/rgl` subcommand is the native one: populate `Module.CommandHandlers` and RGMercs dispatches to it while your module is loaded, then stops the moment it unloads. Pick a distinctive subcommand name — `/rgl` offers the command to every loaded module, and built-in commands match on prefix, so a short name can be swallowed by one of them.
+
+A standalone slash command like `/mybind` goes through `self:RegisterBind`, which is a tracked `mq.bind`.
+
+## Settings persistence
+
+Disabling a module clears its settings from memory but leaves them in the database, so re-enabling restores everything the user had configured. The module also keeps its position in the list while disabled.
+
+Deleting the file leaves the row behind, marked "File missing" — the trash button forgets it. The module's own saved settings survive that, and RGMercs' existing database cleanup is the way to remove them.
+
+## What your module can reach
+
+Everything RGMercs' own modules use, via the usual requires: `utils.config`, `utils.globals`, `utils.targeting`, `utils.casting`, `utils.core`, `utils.comms`, `utils.logger`, `utils.modules` and the rest of `utils/`.
+
+## Things worth knowing
+
+Every rescan executes the top level of every file in the folder — including files you have not enabled — in order to read its `_name`. Keep top-level code to requires and table construction, and put anything with an effect in `Init()`. A bind, event or actor registered at file scope runs again on every rescan and cannot be torn down, because the loader only tracks what you register through `self:Register*`.
+
+Loading and unloading happen on the main loop rather than while the UI is drawing, so a slow `Init()` stalls RGMercs instead of freezing the window. Avoid `mq.delay` there regardless.
+
+`_name` is read directly off your module table, so inheriting it from Base does not count — declare your own.
+
+Your module is not sandboxed. An error thrown from `GiveTime()` surfaces as a normal Lua error, and RGMercs does not check your module against its own version, so an RGMercs upgrade can break a module that reaches into internals.

--- a/extras/hello_world.lua
+++ b/extras/hello_world.lua
@@ -13,7 +13,12 @@ local Config   = require('utils.config')
 local Globals  = require("utils.globals")
 local Logger   = require("utils.logger")
 
-local Module   = { _version = '1.0', _name = "HelloWorld", _author = 'RGMercs', }
+local Module   = {
+    _version = '1.0',
+    _name = "HelloWorld",
+    _author = 'RGMercs',
+    _about = "A working example module. Draws its own tab, adds a setting, answers /rgl hello, and greets you when you zone.",
+}
 Module.__index = Module
 setmetatable(Module, { __index = Base, })
 

--- a/extras/hello_world.lua
+++ b/extras/hello_world.lua
@@ -1,0 +1,103 @@
+-- Hello World - a working example user module for RGMercs.
+--
+-- Enable it on the UserModules tab to see it run, then copy this file under a
+-- new name, change _name, and make it your own.
+--
+-- The full authoring guide is docs/user_modules.md in your RGMercs folder.
+
+local mq       = require('mq')
+local ImGui    = require('ImGui')
+local Base     = require("modules.base")
+local Comms    = require("utils.comms")
+local Config   = require('utils.config')
+local Globals  = require("utils.globals")
+local Logger   = require("utils.logger")
+
+local Module   = { _version = '1.0', _name = "HelloWorld", _author = 'RGMercs', }
+Module.__index = Module
+setmetatable(Module, { __index = Base, })
+
+Module.TempSettings    = {}
+
+Module.CommandHandlers = {
+    hello = {
+        usage = "/rgl hello",
+        about = "Say hello from the Hello World example module.",
+        handler = function(self)
+            Comms.PrintGroupMessage("Hello from %s, running on %s!", self._name, Globals.CurLoadedChar)
+            return true
+        end,
+    },
+}
+
+Module.FAQ             = {
+    {
+        Question = "What is the Hello World module?",
+        Answer =
+            "  A working example user module, shipped with RGMercs so there is something running to copy from. It draws this tab, adds a setting, answers /rgl hello, and says hello in your log when you zone.\n\n" ..
+            "  To start your own, copy hello_world.lua in (MQconfigdir)/rgmercs/modules under a new name and change its _name. The full guide is docs/user_modules.md in your RGMercs folder.",
+        Settings_Used = "HelloWorldGreetOnZone",
+    },
+}
+
+Module.DefaultConfig   = {
+    [string.format("%s_Popped", Module._name)] = {
+        DisplayName = Module._name .. " Popped",
+        Type = "Custom",
+        Default = false,
+    },
+    ['HelloWorldGreetOnZone'] = {
+        DisplayName = "Greet On Zone",
+        Group = "General",
+        Header = "Hello World",
+        Category = "Hello World",
+        Index = 1,
+        Tooltip = "Say hello in your log after every zone.",
+        Default = false,
+        FAQ = "Can a user module react to what I am doing?",
+        Answer = "Yes. A module can override the same hooks RGMercs uses - zoning, death, combat and target changes. " ..
+            "Greet On Zone is the example.",
+    },
+}
+
+function Module:New()
+    return Base.New(self)
+end
+
+function Module:Init()
+    Base.Init(self)
+    Logger.log_info("\agHello, Norrath! \ax%s is loaded.", self._name)
+end
+
+function Module:OnZone()
+    if not Config:GetSetting('HelloWorldGreetOnZone') then return end
+
+    Logger.log_info("\agHello from \at%s\ag! Welcome to \at%s\ag.", self._name, mq.TLO.Zone.Name() or "parts unknown")
+end
+
+function Module:ShouldRender()
+    return true
+end
+
+function Module:Render()
+    Base.Render(self)
+
+    if not self.ModuleLoaded then return end
+
+    ImGui.TextWrapped(string.format("Hello, %s!", Globals.CurLoadedChar))
+    ImGui.Spacing()
+    ImGui.TextWrapped("This tab is drawn by a user module living in your MQ config folder. Copy the file, change _name, and it becomes yours.")
+    ImGui.Spacing()
+    ImGui.TextWrapped("Guide: docs/user_modules.md in your RGMercs folder.")
+    ImGui.Spacing()
+
+    if ImGui.SmallButton("Say Hello") then
+        Comms.PrintGroupMessage("Hello from %s!", self._name)
+    end
+end
+
+function Module:Shutdown()
+    Logger.log_info("\ayGoodbye from %s.", self._name)
+end
+
+return Module

--- a/init.lua
+++ b/init.lua
@@ -300,6 +300,7 @@ local function RGInit(...)
     initMsg = "Initializing Modules..."
     -- complex objects are passed by reference so we can just use these without having to pass them back in for saving.
     Modules:ExecAll("Init")
+    Modules:SyncUserModules()
     Globals.SubmodulesLoaded = true
 
     initPctComplete = 30
@@ -648,6 +649,7 @@ RGInit(...)
 
 while openGUI do
     Main()
+    Modules:ProcessUserModuleSync()
     mq.doevents()
     mq.delay(10)
 end
@@ -655,5 +657,11 @@ end
 Core.CheckPlugins(unloadedPlugins, true)
 
 Targeting.ClearWatchedXTs()
-Modules:ExecAll("Shutdown")
+for _, moduleName in ipairs(Modules:GetModuleOrderedNames()) do
+    local shutdownOk, shutdownError = pcall(function() Modules:ExecModule(moduleName, "Shutdown") end)
+    if not shutdownOk then
+        Logger.log_error("\ar%s errored during shutdown: %s", moduleName, shutdownError)
+    end
+end
+
 Config:Shutdown()

--- a/modules/base.lua
+++ b/modules/base.lua
@@ -1,4 +1,5 @@
 local mq           = require('mq')
+local Actors       = require('actors')
 local Config       = require('utils.config')
 local Globals      = require("utils.globals")
 local Logger       = require("utils.logger")
@@ -97,13 +98,15 @@ end
 ---@param ... string
 ---@return boolean
 function Base:HandleBind(cmd, ...)
-    if self.CommandHandlers[cmd:lower()] ~= nil then
-        self.CommandHandlers[cmd:lower()].handler(self, ...)
+    local commandHandlers = self.CommandHandlers or {}
+
+    if commandHandlers[cmd:lower()] ~= nil then
+        commandHandlers[cmd:lower()].handler(self, ...)
         return true
     end
 
     -- try to process as a substring
-    for bindCmd, bindData in pairs(self.CommandHandlers or {}) do
+    for bindCmd, bindData in pairs(commandHandlers) do
         if Strings.StartsWith(bindCmd, cmd) then
             bindData.handler(self, ...)
             return true
@@ -111,6 +114,37 @@ function Base:HandleBind(cmd, ...)
     end
 
     return false
+end
+
+function Base:RegisterEvent(name, pattern, callback, options)
+    mq.event(name, pattern, callback, options)
+    self._trackedEvents = self._trackedEvents or {}
+    table.insert(self._trackedEvents, name)
+end
+
+function Base:RegisterBind(slash, callback)
+    mq.bind(slash, callback)
+    self._trackedBinds = self._trackedBinds or {}
+    table.insert(self._trackedBinds, slash)
+end
+
+function Base:RegisterImGui(name, callback)
+    mq.imgui.init(name, callback)
+    self._trackedImGui = self._trackedImGui or {}
+    table.insert(self._trackedImGui, name)
+end
+
+function Base:RegisterActor(mailbox, handler)
+    local dropbox
+    if type(mailbox) == "function" then
+        dropbox = Actors.register(mailbox)
+    else
+        dropbox = Actors.register(mailbox, handler)
+    end
+
+    self._trackedActors = self._trackedActors or {}
+    table.insert(self._trackedActors, dropbox)
+    return dropbox
 end
 
 function Base:Shutdown()

--- a/modules/lootnscoot.lua
+++ b/modules/lootnscoot.lua
@@ -233,7 +233,7 @@ function Module.DoLooting()
 end
 
 function Module:LootMessageHandler()
-    self.Actor = Actors.register('loot_module', function(message)
+    Module.Actor = Actors.register('loot_module', function(message)
         local mail = message()
         local subject = mail.Subject or ''
         local who = mail.Who or ''
@@ -246,6 +246,18 @@ function Module:LootMessageHandler()
             Module.TempSettings.Looting = true
         end
     end)
+end
+
+function Module:Shutdown()
+    Logger.log_debug("\ay[LOOT]: \axLootNScoot Integration Module Unloaded.")
+    if Config:GetSetting('DoLoot') and mq.TLO.Lua.Script('lootnscoot').Status() == 'RUNNING' then
+        Core.DoCmd("/lua stop lootnscoot")
+    end
+
+    if Module.Actor then
+        Module.Actor:unregister()
+        Module.Actor = nil
+    end
 end
 
 function Module:CheckChaseTargetInRange()
@@ -349,7 +361,7 @@ function Module:GiveTime()
     local myCorpseCount = mq.TLO.SpawnCount(string.format("pccorpse %s radius 100 zradius 50", mq.TLO.Me.CleanName()))()
     if myCorpseCount > 0 then deadCount = deadCount + 1 end
     Logger.log_verbose("\ay[LOOT]: \agFound %d corpses within range.", deadCount)
-    if self.Actor == nil then self:LootMessageHandler() end
+    if Module.Actor == nil then self:LootMessageHandler() end
 
     local settled = Config:GetSetting('CombatLooting') or Combat.CombatSettled(Config:GetSetting('LootDelay') * 1000)
 
@@ -361,8 +373,8 @@ function Module:GiveTime()
     if (combat_state ~= "Combat" or Config:GetSetting('CombatLooting')) and deadCount > 0 then
         if not settled then
             Logger.log_super_verbose("\ay::LOOT:: \arHolding!\ax Waiting for combat to settle before looting.")
-        elseif not self.TempSettings.Looting then
-            self.Actor:send({ mailbox = 'lootnscoot', script = 'lootnscoot', },
+        elseif not self.TempSettings.Looting and Module.Actor then
+            Module.Actor:send({ mailbox = 'lootnscoot', script = 'lootnscoot', },
                 { who = Globals.CurLoadedChar, server = serverLNSFormat, directions = 'doloot', })
             self.TempSettings.Looting = true
         end

--- a/modules/lootnscoot.lua
+++ b/modules/lootnscoot.lua
@@ -1,6 +1,5 @@
 -- Sample Basic Class Module
 local mq              = require('mq')
-local Actors          = require("actors")
 local Base            = require("modules.base")
 local Combat          = require("utils.combat")
 local Comms           = require("utils.comms")
@@ -46,7 +45,6 @@ Module.DefaultConfig   = {
             if newValue == true and mq.TLO.Lua.Script('lootnscoot').Status() ~= 'RUNNING' then
                 Core.DoCmd("/lua run lootnscoot directed rgmercs")
                 suppressWarning = true
-                if not Module.Actor then Module:LootMessageHandler() end
             elseif newValue == false and mq.TLO.Lua.Script('lootnscoot').Status() == 'RUNNING' then
                 Core.DoCmd("/lua stop lootnscoot")
             end
@@ -233,7 +231,7 @@ function Module.DoLooting()
 end
 
 function Module:LootMessageHandler()
-    Module.Actor = Actors.register('loot_module', function(message)
+    self.Actor = self:RegisterActor('loot_module', function(message)
         local mail = message()
         local subject = mail.Subject or ''
         local who = mail.Who or ''
@@ -252,11 +250,6 @@ function Module:Shutdown()
     Logger.log_debug("\ay[LOOT]: \axLootNScoot Integration Module Unloaded.")
     if Config:GetSetting('DoLoot') and mq.TLO.Lua.Script('lootnscoot').Status() == 'RUNNING' then
         Core.DoCmd("/lua stop lootnscoot")
-    end
-
-    if Module.Actor then
-        Module.Actor:unregister()
-        Module.Actor = nil
     end
 end
 
@@ -361,7 +354,6 @@ function Module:GiveTime()
     local myCorpseCount = mq.TLO.SpawnCount(string.format("pccorpse %s radius 100 zradius 50", mq.TLO.Me.CleanName()))()
     if myCorpseCount > 0 then deadCount = deadCount + 1 end
     Logger.log_verbose("\ay[LOOT]: \agFound %d corpses within range.", deadCount)
-    if Module.Actor == nil then self:LootMessageHandler() end
 
     local settled = Config:GetSetting('CombatLooting') or Combat.CombatSettled(Config:GetSetting('LootDelay') * 1000)
 
@@ -373,8 +365,8 @@ function Module:GiveTime()
     if (combat_state ~= "Combat" or Config:GetSetting('CombatLooting')) and deadCount > 0 then
         if not settled then
             Logger.log_super_verbose("\ay::LOOT:: \arHolding!\ax Waiting for combat to settle before looting.")
-        elseif not self.TempSettings.Looting and Module.Actor then
-            Module.Actor:send({ mailbox = 'lootnscoot', script = 'lootnscoot', },
+        elseif not self.TempSettings.Looting then
+            self.Actor:send({ mailbox = 'lootnscoot', script = 'lootnscoot', },
                 { who = Globals.CurLoadedChar, server = serverLNSFormat, directions = 'doloot', })
             self.TempSettings.Looting = true
         end

--- a/modules/smartloot.lua
+++ b/modules/smartloot.lua
@@ -313,6 +313,11 @@ end
 
 function Module:Shutdown()
     Logger.log_debug("\ay[LOOT]: \axSmartLoot Integration Module Unloaded.")
+
+    if Config:GetSetting('UseSmartLoot') and self:SLRunning() then
+        Core.DoCmd('/lua stop smartloot')
+    end
+
     -- Clear any pending loot state
     self.TempSettings.Looting = false
     self.TempSettings.LootStartTime = nil

--- a/modules/usermodules.lua
+++ b/modules/usermodules.lua
@@ -65,6 +65,21 @@ function Module:New()
     return Base.New(self)
 end
 
+--- Puts the user module authoring guide on the clipboard.
+function Module:CopyGuideToClipboard()
+    local guidePath = string.format("%s/docs/user_modules.md", Globals.ScriptDir)
+    local guide = io.open(guidePath, "r")
+    if not guide then
+        Logger.log_error("\arCould not find the user module guide at: %s", guidePath)
+        return
+    end
+
+    local contents = guide:read("*all")
+    guide:close()
+    ImGui.SetClipboardText(contents)
+    Logger.log_info("\agThe user module guide has been copied to your clipboard.")
+end
+
 function Module:Init()
     Base.Init(self)
 end
@@ -100,7 +115,6 @@ function Module:SetModuleEnabled(moduleName, enabled)
         if entry.name and entry.name:lower() == moduleName:lower() then manifestEntry = entry end
     end
 
-    -- Fall back to the filename so a module that failed to load reports its error instead of going missing.
     for _, entry in ipairs(Globals.UserModuleManifest) do
         if not manifestEntry and entry.fileName:lower():gsub("%.lua$", "") == moduleName:lower():gsub("%.lua$", "") then manifestEntry = entry end
     end
@@ -147,27 +161,43 @@ function Module:MoveModuleDown(idx)
     Config:SetSetting('UserModuleList', moduleList)
 end
 
-function Module:DeleteModule(idx)
-    local moduleList = Config:GetSetting('UserModuleList') or {}
-    if not moduleList[idx] then return end
-
-    table.remove(moduleList, idx)
-    Config:SetSetting('UserModuleList', moduleList)
-    Modules:RequestUserModuleSync()
-end
-
 function Module:Render()
-    Base.Render(self)
+    local controlPadding = Base.Render(self)
 
     if not self.ModuleLoaded then return end
 
-    if ImGui.SmallButton("Refresh") then
+    local moduleList = Config:GetSetting('UserModuleList') or {}
+    local loadedCount = 0
+    for _, listEntry in ipairs(moduleList) do
+        if Modules.LoadedUserModules[listEntry.name] then loadedCount = loadedCount + 1 end
+    end
+
+    if ImGui.BeginTable("##UserModulesInfo", 2, bit32.bor(ImGuiTableFlags.BordersInner, ImGuiTableFlags.SizingFixedFit),
+            ImVec2(ImGui.GetWindowWidth() - (controlPadding + 20), 0)) then
+        ImGui.TableNextColumn()
+        Ui.RenderText("Modules Folder")
+        ImGui.TableNextColumn()
+        Ui.RenderText("%s/rgmercs/modules", mq.configDir)
+        ImGui.TableNextColumn()
+        Ui.RenderText("Loaded")
+        ImGui.TableNextColumn()
+        Ui.RenderColoredText(loadedCount > 0 and Globals.Constants.Colors.ConditionPassColor or Globals.Constants.Colors.ConditionDisabledColor,
+            "%d of %d", loadedCount, #moduleList)
+        ImGui.EndTable()
+    end
+
+    if ImGui.SmallButton(Icons.MD_REFRESH .. " Refresh") then
         Modules:RequestUserModuleSync()
     end
+    Ui.Tooltip("Rescan the modules folder and apply any changes.")
     ImGui.SameLine()
-    Ui.RenderText(string.format("%s/rgmercs/modules", mq.configDir))
+    if ImGui.SmallButton("Copy Guide") then
+        self:CopyGuideToClipboard()
+    end
+    Ui.Tooltip("Copy the user module authoring guide to your clipboard.")
 
-    local moduleList = Config:GetSetting('UserModuleList') or {}
+    ImGui.Separator()
+
     local shownFiles = {}
     local rows = {}
 
@@ -188,12 +218,13 @@ function Module:Render()
         return
     end
 
-    if ImGui.BeginTable("UserModulesTable", 7, bit32.bor(ImGuiTableFlags.Borders, ImGuiTableFlags.RowBg)) then
+    if ImGui.BeginTable("UserModulesTable", 8, bit32.bor(ImGuiTableFlags.Borders, ImGuiTableFlags.Resizable)) then
         ImGui.TableSetupColumn('Enabled', ImGuiTableColumnFlags.WidthFixed, 55.0)
-        ImGui.TableSetupColumn('Name', ImGuiTableColumnFlags.WidthFixed, 120.0)
+        ImGui.TableSetupColumn('Name', ImGuiTableColumnFlags.WidthFixed, 140.0)
         ImGui.TableSetupColumn('File', ImGuiTableColumnFlags.WidthFixed, 140.0)
         ImGui.TableSetupColumn('Version', ImGuiTableColumnFlags.WidthFixed, 55.0)
         ImGui.TableSetupColumn('Author', ImGuiTableColumnFlags.WidthFixed, 90.0)
+        ImGui.TableSetupColumn('ms', ImGuiTableColumnFlags.WidthFixed, 45.0)
         ImGui.TableSetupColumn('Status', ImGuiTableColumnFlags.WidthStretch, 150.0)
         ImGui.TableSetupColumn('Controls', ImGuiTableColumnFlags.WidthFixed, 80.0)
         ImGui.TableHeadersRow()
@@ -206,23 +237,32 @@ function Module:Render()
 
             ImGui.PushID("##_user_module_" .. (row.name or "") .. "_" .. rowKey)
 
+            local canToggle = loadable or row.idx ~= nil
+
             ImGui.TableNextColumn()
-            if loadable or row.idx then
-                local _, toggled = Ui.RenderOptionToggle("user_module_tggl_" .. rowKey, "", row.enabled)
-                if toggled then
-                    if row.idx then
-                        self:ToggleModule(row.idx)
-                    else
-                        self:AddModule(manifestEntry)
-                    end
-                end
-            else
-                Ui.RenderColoredText(Globals.Constants.Colors.ConditionFailColor, Icons.FA_BAN)
+            ImGui.BeginGroup()
+            ImGui.BeginDisabled(not canToggle)
+            local _, toggled = Ui.RenderOptionToggle("user_module_tggl_" .. rowKey, "", row.enabled)
+            ImGui.EndDisabled()
+            ImGui.EndGroup()
+            if not canToggle then
                 Ui.Tooltip("This module can't be loaded until the problem in the Status column is fixed.")
+            end
+            if toggled then
+                if row.idx then
+                    self:ToggleModule(row.idx)
+                else
+                    self:AddModule(manifestEntry)
+                end
             end
 
             ImGui.TableNextColumn()
             Ui.RenderText(row.name or "?")
+            if manifestEntry and manifestEntry.about then
+                ImGui.SameLine()
+                Ui.RenderColoredText(Globals.Constants.Colors.ConditionMidColor, Icons.MD_INFO_OUTLINE)
+                Ui.Tooltip(manifestEntry.about)
+            end
             ImGui.TableNextColumn()
             Ui.RenderText(manifestEntry and manifestEntry.fileName or "-")
             ImGui.TableNextColumn()
@@ -231,11 +271,22 @@ function Module:Render()
             Ui.RenderText(tostring(manifestEntry and manifestEntry.author or "-"))
 
             ImGui.TableNextColumn()
+            local frameTime = Modules.UserModuleFrameTimes[row.name]
+            if isLoaded and frameTime then
+                Ui.RenderColoredText(frameTime < 5 and Globals.Constants.Colors.ConditionPassColor or
+                    (frameTime < 15 and Globals.Constants.Colors.ConditionMidColor or Globals.Constants.Colors.ConditionFailColor),
+                    "%d", math.floor(frameTime + 0.5))
+                Ui.Tooltip("Average time this module spends in the RGMercs loop each pass, to the nearest millisecond.")
+            else
+                Ui.RenderColoredText(Globals.Constants.Colors.ConditionDisabledColor, "-")
+            end
+
+            ImGui.TableNextColumn()
             if isLoaded then
                 Ui.RenderColoredText(Globals.Constants.Colors.ConditionPassColor, "Loaded")
             elseif not manifestEntry then
                 Ui.RenderColoredText(Globals.Constants.Colors.ConditionFailColor, "File missing")
-                Ui.Tooltip("No file in the modules folder matches this entry. Delete the row to forget it.")
+                Ui.Tooltip("No file in the modules folder matches this entry. It will be forgotten on the next refresh.")
             elseif manifestEntry.collisionWith then
                 Ui.RenderColoredText(Globals.Constants.Colors.ConditionFailColor, "Name taken by %s", manifestEntry.collisionWith)
                 Ui.Tooltip("Another module already uses this name. Change _name in this file and press Refresh.")
@@ -262,11 +313,6 @@ function Module:Render()
                 elseif ImGui.SmallButton(Icons.FA_CHEVRON_DOWN) then
                     self:MoveModuleDown(row.idx)
                 end
-                ImGui.SameLine()
-                if ImGui.SmallButton(Icons.FA_TRASH) then
-                    self:DeleteModule(row.idx)
-                end
-                Ui.Tooltip("Forget this module and unload it.")
             end
 
             ImGui.PopID()

--- a/modules/usermodules.lua
+++ b/modules/usermodules.lua
@@ -1,0 +1,281 @@
+local mq       = require('mq')
+local Icons    = require('mq.ICONS')
+local ImGui    = require('ImGui')
+local Base     = require("modules.base")
+local Config   = require('utils.config')
+local Core     = require("utils.core")
+local Globals  = require('utils.globals')
+local Logger   = require('utils.logger')
+local Modules  = require("utils.modules")
+local Ui       = require('utils.ui')
+
+local Module   = { _version = '1.0', _name = "UserModules", _author = 'Algar', }
+Module.__index = Module
+setmetatable(Module, { __index = Base, })
+
+Module.CommandHandlers = {
+    usermodule = {
+        usage = "/rgl usermodule <name> <on|off>",
+        about = "Enable or disable a user module by its declared name, without opening the UserModules tab.",
+        handler = function(self, moduleName, state)
+            state = (state or ""):lower()
+            if not moduleName or (state ~= "on" and state ~= "off") then
+                Logger.log_error("\arUsage: /rgl usermodule <name> <on|off>")
+                return true
+            end
+
+            self:SetModuleEnabled(moduleName, state == "on")
+            return true
+        end,
+    },
+}
+
+Module.FAQ             = {
+    {
+        Question = "How do I add my own module to RGMercs?",
+        Answer =
+            "  The GUI can be found on the UserModules tab. Any .lua file placed in (MQconfigdir)/rgmercs/modules will appear in the list after a Refresh, where it can be enabled, reordered, or turned back off.\n\n" ..
+            "  A working example, hello_world.lua, is placed in that folder for you. Enable it to watch a user module run, then copy it under a new name and change its _name to begin your own.\n\n" ..
+            "  Your module runs in the RGMercs loop alongside the built-in modules, with access to the same settings, lifecycle hooks, tab and commands they use. The full guide is docs/user_modules.md in your RGMercs folder.\n\n" ..
+            "  If a module will not enable, the Status column will say why - most often the file failed to load, or the name it declares is already in use. Hover the status for details.\n\n" ..
+            "  /rgl usermodule <name> <on|off> enables or disables a module from the command line.\n\n" ..
+            "  Please bear in mind that a user module is your own code running inside RGMercs, and a misbehaving one can affect the rest of the script. Feedback on the hooks and helpers available to you is welcome.",
+        Settings_Used = "UserModuleList",
+    },
+}
+
+Module.DefaultConfig   = {
+    [string.format("%s_Popped", Module._name)] = {
+        DisplayName = Module._name .. " Popped",
+        Type = "Custom",
+        Default = false,
+    },
+    ['UserModuleList'] = {
+        DisplayName = "User Modules",
+        Type = "Custom",
+        Default = {},
+        FAQ = "Does the order of my user modules matter?",
+        Answer = "Modules load in the order shown on the UserModules tab, and the arrows reorder them. " ..
+            "Turning one off keeps its place in the list and its saved settings, so enabling it again restores what you had.\n\n" ..
+            "This list is saved per character and per class, the same as your other settings, so swapping personas loads that class's set of modules.",
+    },
+}
+
+function Module:New()
+    return Base.New(self)
+end
+
+function Module:Init()
+    Base.Init(self)
+end
+
+function Module:ShouldRender()
+    return true
+end
+
+--- Appends a newly discovered module to the saved list and asks for a sync.
+function Module:AddModule(manifestEntry)
+    local moduleList = Config:GetSetting('UserModuleList') or {}
+    table.insert(moduleList, { name = manifestEntry.name, file = manifestEntry.fileName, enabled = true, })
+    Config:SetSetting('UserModuleList', moduleList)
+    Modules:RequestUserModuleSync()
+end
+
+function Module:ToggleModule(idx)
+    local moduleList = Config:GetSetting('UserModuleList') or {}
+    local listEntry = moduleList[idx]
+    if not listEntry then return end
+
+    listEntry.enabled = not listEntry.enabled
+    Config:SetSetting('UserModuleList', moduleList)
+    Modules:RequestUserModuleSync()
+end
+
+--- Sets a module's enabled state by declared name, adding it to the saved list if it isn't there yet.
+function Module:SetModuleEnabled(moduleName, enabled)
+    Core.ScanUserModules()
+
+    local manifestEntry = nil
+    for _, entry in ipairs(Globals.UserModuleManifest) do
+        if entry.name and entry.name:lower() == moduleName:lower() then manifestEntry = entry end
+    end
+
+    -- Fall back to the filename so a module that failed to load reports its error instead of going missing.
+    for _, entry in ipairs(Globals.UserModuleManifest) do
+        if not manifestEntry and entry.fileName:lower():gsub("%.lua$", "") == moduleName:lower():gsub("%.lua$", "") then manifestEntry = entry end
+    end
+
+    if not manifestEntry then
+        Logger.log_error("\arNo user module named \at%s\ar was found in %s/rgmercs/modules.", moduleName, mq.configDir)
+        return
+    end
+
+    if manifestEntry.error or manifestEntry.collisionWith then
+        Logger.log_error("\ar%s can't be loaded: %s", manifestEntry.name or manifestEntry.fileName,
+            manifestEntry.error or ("its name collides with " .. manifestEntry.collisionWith))
+        return
+    end
+
+    local moduleList = Config:GetSetting('UserModuleList') or {}
+    local listEntry = nil
+    for _, entry in ipairs(moduleList) do
+        if entry.name == manifestEntry.name then listEntry = entry end
+    end
+
+    if not listEntry then
+        listEntry = { name = manifestEntry.name, file = manifestEntry.fileName, }
+        table.insert(moduleList, listEntry)
+    end
+
+    listEntry.enabled = enabled
+    Config:SetSetting('UserModuleList', moduleList)
+    Modules:RequestUserModuleSync()
+    Logger.log_info("\ag%s\ax user module \at%s\ax.", enabled and "Enabled" or "Disabled", manifestEntry.name)
+end
+
+function Module:MoveModuleUp(idx)
+    local moduleList = Config:GetSetting('UserModuleList') or {}
+    if idx < 2 or idx > #moduleList then return end
+    moduleList[idx - 1], moduleList[idx] = moduleList[idx], moduleList[idx - 1]
+    Config:SetSetting('UserModuleList', moduleList)
+end
+
+function Module:MoveModuleDown(idx)
+    local moduleList = Config:GetSetting('UserModuleList') or {}
+    if idx < 1 or idx + 1 > #moduleList then return end
+    moduleList[idx + 1], moduleList[idx] = moduleList[idx], moduleList[idx + 1]
+    Config:SetSetting('UserModuleList', moduleList)
+end
+
+function Module:DeleteModule(idx)
+    local moduleList = Config:GetSetting('UserModuleList') or {}
+    if not moduleList[idx] then return end
+
+    table.remove(moduleList, idx)
+    Config:SetSetting('UserModuleList', moduleList)
+    Modules:RequestUserModuleSync()
+end
+
+function Module:Render()
+    Base.Render(self)
+
+    if not self.ModuleLoaded then return end
+
+    if ImGui.SmallButton("Refresh") then
+        Modules:RequestUserModuleSync()
+    end
+    ImGui.SameLine()
+    Ui.RenderText(string.format("%s/rgmercs/modules", mq.configDir))
+
+    local moduleList = Config:GetSetting('UserModuleList') or {}
+    local shownFiles = {}
+    local rows = {}
+
+    for idx, listEntry in ipairs(moduleList) do
+        local manifestEntry = Core.FindUserModule(listEntry.name, listEntry.file)
+        if manifestEntry then shownFiles[manifestEntry.fileName] = true end
+        table.insert(rows, { idx = idx, name = listEntry.name, enabled = listEntry.enabled, manifest = manifestEntry, })
+    end
+
+    for _, manifestEntry in ipairs(Globals.UserModuleManifest) do
+        if not shownFiles[manifestEntry.fileName] then
+            table.insert(rows, { name = manifestEntry.name, enabled = false, manifest = manifestEntry, })
+        end
+    end
+
+    if #rows == 0 then
+        Ui.RenderColoredText(Globals.Constants.Colors.ConditionDisabledColor, "No user modules found. Drop a .lua module in the folder above and press Refresh.")
+        return
+    end
+
+    if ImGui.BeginTable("UserModulesTable", 7, bit32.bor(ImGuiTableFlags.Borders, ImGuiTableFlags.RowBg)) then
+        ImGui.TableSetupColumn('Enabled', ImGuiTableColumnFlags.WidthFixed, 55.0)
+        ImGui.TableSetupColumn('Name', ImGuiTableColumnFlags.WidthFixed, 120.0)
+        ImGui.TableSetupColumn('File', ImGuiTableColumnFlags.WidthFixed, 140.0)
+        ImGui.TableSetupColumn('Version', ImGuiTableColumnFlags.WidthFixed, 55.0)
+        ImGui.TableSetupColumn('Author', ImGuiTableColumnFlags.WidthFixed, 90.0)
+        ImGui.TableSetupColumn('Status', ImGuiTableColumnFlags.WidthStretch, 150.0)
+        ImGui.TableSetupColumn('Controls', ImGuiTableColumnFlags.WidthFixed, 80.0)
+        ImGui.TableHeadersRow()
+
+        for _, row in ipairs(rows) do
+            local manifestEntry = row.manifest
+            local rowKey = row.idx or manifestEntry.fileName
+            local loadable = manifestEntry ~= nil and manifestEntry.error == nil and manifestEntry.collisionWith == nil
+            local isLoaded = manifestEntry ~= nil and Modules.LoadedUserModules[row.name] == manifestEntry.filePath
+
+            ImGui.PushID("##_user_module_" .. (row.name or "") .. "_" .. rowKey)
+
+            ImGui.TableNextColumn()
+            if loadable or row.idx then
+                local _, toggled = Ui.RenderOptionToggle("user_module_tggl_" .. rowKey, "", row.enabled)
+                if toggled then
+                    if row.idx then
+                        self:ToggleModule(row.idx)
+                    else
+                        self:AddModule(manifestEntry)
+                    end
+                end
+            else
+                Ui.RenderColoredText(Globals.Constants.Colors.ConditionFailColor, Icons.FA_BAN)
+                Ui.Tooltip("This module can't be loaded until the problem in the Status column is fixed.")
+            end
+
+            ImGui.TableNextColumn()
+            Ui.RenderText(row.name or "?")
+            ImGui.TableNextColumn()
+            Ui.RenderText(manifestEntry and manifestEntry.fileName or "-")
+            ImGui.TableNextColumn()
+            Ui.RenderText(tostring(manifestEntry and manifestEntry.version or "-"))
+            ImGui.TableNextColumn()
+            Ui.RenderText(tostring(manifestEntry and manifestEntry.author or "-"))
+
+            ImGui.TableNextColumn()
+            if isLoaded then
+                Ui.RenderColoredText(Globals.Constants.Colors.ConditionPassColor, "Loaded")
+            elseif not manifestEntry then
+                Ui.RenderColoredText(Globals.Constants.Colors.ConditionFailColor, "File missing")
+                Ui.Tooltip("No file in the modules folder matches this entry. Delete the row to forget it.")
+            elseif manifestEntry.collisionWith then
+                Ui.RenderColoredText(Globals.Constants.Colors.ConditionFailColor, "Name taken by %s", manifestEntry.collisionWith)
+                Ui.Tooltip("Another module already uses this name. Change _name in this file and press Refresh.")
+            elseif manifestEntry.error then
+                Ui.RenderColoredText(Globals.Constants.Colors.ConditionFailColor, "Load error")
+                Ui.Tooltip(manifestEntry.error)
+            elseif Modules.UserModuleLoadErrors[row.name] then
+                Ui.RenderColoredText(Globals.Constants.Colors.ConditionFailColor, "Load failed")
+                Ui.Tooltip(Modules.UserModuleLoadErrors[row.name])
+            else
+                Ui.RenderColoredText(Globals.Constants.Colors.ConditionDisabledColor, "Not loaded")
+            end
+
+            ImGui.TableNextColumn()
+            if row.idx then
+                if row.idx == 1 then
+                    ImGui.InvisibleButton(Icons.FA_CHEVRON_UP, ImVec2(22, 1))
+                elseif ImGui.SmallButton(Icons.FA_CHEVRON_UP) then
+                    self:MoveModuleUp(row.idx)
+                end
+                ImGui.SameLine()
+                if row.idx == #moduleList then
+                    ImGui.InvisibleButton(Icons.FA_CHEVRON_DOWN, ImVec2(22, 1))
+                elseif ImGui.SmallButton(Icons.FA_CHEVRON_DOWN) then
+                    self:MoveModuleDown(row.idx)
+                end
+                ImGui.SameLine()
+                if ImGui.SmallButton(Icons.FA_TRASH) then
+                    self:DeleteModule(row.idx)
+                end
+                Ui.Tooltip("Forget this module and unload it.")
+            end
+
+            ImGui.PopID()
+        end
+
+        ImGui.EndTable()
+    end
+
+    Ui.RenderColoredText(Globals.Constants.Colors.ConditionDisabledColor, "Load order applies the next time a module is loaded.")
+end
+
+return Module

--- a/utils/classloader.lua
+++ b/utils/classloader.lua
@@ -157,6 +157,7 @@ function ClassLoader.reloadConfig()
     Config:LoadSettings()
     Core.ScanConfigDirs()
     Modules:ExecAll("LoadSettings")
+    Modules:RequestUserModuleSync()
     Config:UpdateCommandHandlers()
 end
 

--- a/utils/config.lua
+++ b/utils/config.lua
@@ -3724,13 +3724,13 @@ function Config.ResolveDefaults(defaults, settings, module)
         end
 
         if settings[k] == nil then
-            settings[k] = v.Default
+            settings[k] = type(v.Default) == "table" and Tables.DeepCopy(v.Default) or v.Default
             changed = true
         end
 
         if type(settings[k]) ~= type(v.Default) then
             Logger.log_warn("\ayData type of setting [\am%s\ay] has been deprecated -- resetting to default.", k)
-            settings[k] = v.Default
+            settings[k] = type(v.Default) == "table" and Tables.DeepCopy(v.Default) or v.Default
             changed = true
         elseif v.Type == "Combo" and settings[k] > #v.ComboOptions then
             Logger.log_warn("\aySetting value out of bounds [\am%s\ay] -- resetting to default.", k)

--- a/utils/config.lua
+++ b/utils/config.lua
@@ -3759,6 +3759,8 @@ function Config.ResolveDefaults(defaults, settings, module)
 end
 
 function Config:UnRegisterCategoryToSettingMapping(setting)
+    if not Config.TempSettings.SettingToModuleCache[setting] then return end
+
     local category = Config:GetSettingDefaults(setting).Category
     if self.TempSettings.SettingsCategoryToSettingMapping[category] then
         for i, v in ipairs(self.TempSettings.SettingsCategoryToSettingMapping[category]) do
@@ -3780,6 +3782,23 @@ function Config:PeerRegisterCategoryToSettingMapping(peer, setting)
     local category = Config:PeerGetSettingDefaults(peer, setting).Category
     self.TempSettings.PeerSettingsCategoryToSettingMapping[category] = self.TempSettings.PeerSettingsCategoryToSettingMapping[category] or {}
     table.insert(self.TempSettings.PeerSettingsCategoryToSettingMapping[category], setting)
+end
+
+--- Returns the module already using any setting name in defaultSettings, plus
+--- the offending setting; setting names are matched without regard to case.
+---@param module string Module about to register the settings.
+---@param defaultSettings table? Candidate DefaultConfig table.
+---@return string? owner Name of the module already using one of the setting names.
+---@return string? setting The setting name that is already taken.
+function Config:FindConflictingSettingOwner(module, defaultSettings)
+    for setting in pairs(defaultSettings or {}) do
+        local registeredName = Config.TempSettings.SettingsLowerToNameCache[setting:lower()]
+        local owner = registeredName and Config.TempSettings.SettingToModuleCache[registeredName]
+        if owner and owner ~= module then
+            return owner, setting
+        end
+    end
+    return nil
 end
 
 function Config:RegisterModuleSettings(module, settings, defaultSettings, faq, firstSaveRequired)
@@ -3846,9 +3865,15 @@ function Config:ClearModuleSettings(module)
 
     for setting, _ in pairs(self.moduleDefaultSettings[module]) do
         self:UnRegisterCategoryToSettingMapping(setting)
-        Config.TempSettings.SettingsLowerToNameCache[setting:lower()] = nil
-        Config.TempSettings.SettingToModuleCache[setting] = nil
-        Config.TempSettings.SettingToScopeCache[setting] = nil
+
+        if Config.TempSettings.SettingToModuleCache[setting] == module then
+            Config.TempSettings.SettingToModuleCache[setting] = nil
+            Config.TempSettings.SettingToScopeCache[setting] = nil
+
+            if Config.TempSettings.SettingsLowerToNameCache[setting:lower()] == setting then
+                Config.TempSettings.SettingsLowerToNameCache[setting:lower()] = nil
+            end
+        end
     end
 
     self.moduleTempSettings[module] = nil

--- a/utils/core.lua
+++ b/utils/core.lua
@@ -49,6 +49,7 @@ end
 
 --- Rebuilds Globals.UserModuleManifest from the user modules folder, stamping
 --- parse/runtime errors and name collisions onto the affected entries.
+---@return boolean scanned False when the modules folder could not be read.
 function Core.ScanUserModules()
     Globals.UserModuleManifest = {}
 
@@ -57,12 +58,12 @@ function Core.ScanUserModules()
         local created, mkdirError = Files.make_p(userModuleDir)
         if not created then
             Logger.log_error("\arFailed to create the user modules folder \at%s\ar: %s", userModuleDir, mkdirError)
-            return
+            return false
         end
 
         Files.copy_file(string.format("%s/extras/hello_world.lua", Globals.ScriptDir),
             string.format("%s/hello_world.lua", userModuleDir))
-        return
+        return false
     end
 
     local fileNames = {}
@@ -93,6 +94,7 @@ function Core.ScanUserModules()
                     entry.name = declaredName
                     entry.version = rawget(module, '_version')
                     entry.author = rawget(module, '_author')
+                    entry.about = rawget(module, '_about')
                 end
             end
         end
@@ -134,6 +136,8 @@ function Core.ScanUserModules()
             end
         end
     end
+
+    return true
 end
 
 --- Returns the manifest entry for a saved user module, matching the declared

--- a/utils/core.lua
+++ b/utils/core.lua
@@ -2,6 +2,7 @@ local mq      = require('mq')
 local Comms   = require("utils.comms")
 local Config  = require('utils.config')
 local DanNet  = require('lib.dannet.helpers')
+local Files   = require("utils.files")
 local Globals = require('utils.globals')
 local Logger  = require("utils.logger")
 local LuaFS   = require('lfs')
@@ -44,6 +45,117 @@ function Core.ScanConfigDirs()
             end
         end
     end
+end
+
+--- Rebuilds Globals.UserModuleManifest from the user modules folder, stamping
+--- parse/runtime errors and name collisions onto the affected entries.
+function Core.ScanUserModules()
+    Globals.UserModuleManifest = {}
+
+    local userModuleDir = string.format("%s/rgmercs/modules", mq.configDir)
+    if not LuaFS.attributes(userModuleDir) then
+        local created, mkdirError = Files.make_p(userModuleDir)
+        if not created then
+            Logger.log_error("\arFailed to create the user modules folder \at%s\ar: %s", userModuleDir, mkdirError)
+            return
+        end
+
+        Files.copy_file(string.format("%s/extras/hello_world.lua", Globals.ScriptDir),
+            string.format("%s/hello_world.lua", userModuleDir))
+        return
+    end
+
+    local fileNames = {}
+    for file in LuaFS.dir(userModuleDir) do
+        if file:match("%.lua$") then
+            table.insert(fileNames, file)
+        end
+    end
+    table.sort(fileNames)
+
+    for _, fileName in ipairs(fileNames) do
+        local entry = { fileName = fileName, filePath = string.format("%s/%s", userModuleDir, fileName), }
+        local chunk, loadError = loadfile(entry.filePath)
+
+        if not chunk then
+            entry.error = loadError
+        else
+            local success, module = pcall(chunk)
+            if not success then
+                entry.error = module
+            elseif type(module) ~= "table" then
+                entry.error = "File did not return a module table."
+            else
+                local declaredName = rawget(module, '_name')
+                if type(declaredName) ~= "string" or declaredName == "" then
+                    entry.error = "Module table is missing its own _name string."
+                else
+                    entry.name = declaredName
+                    entry.version = rawget(module, '_version')
+                    entry.author = rawget(module, '_author')
+                end
+            end
+        end
+
+        Logger.log_debug("Found user module file: %s (%s)", fileName, entry.error or entry.name)
+        table.insert(Globals.UserModuleManifest, entry)
+    end
+
+    local claimedNames = {}
+    for moduleName in pairs(Modules:GetModuleList()) do
+        if not Modules.LoadedUserModules[moduleName] then
+            claimedNames[moduleName:lower()] = "an RGMercs module"
+        end
+    end
+
+    for settingsNamespace in pairs(Config.moduleDefaultSettings) do
+        if not Modules.LoadedUserModules[settingsNamespace] then
+            claimedNames[settingsNamespace:lower()] = "an RGMercs module"
+        end
+    end
+
+    for _, lootModule in ipairs(Globals.Constants.LootModuleTypes) do
+        claimedNames[lootModule:lower()] = "an RGMercs module"
+    end
+
+    for _, entry in ipairs(Globals.UserModuleManifest) do
+        if entry.name and Modules.LoadedUserModules[entry.name] == entry.filePath then
+            claimedNames[entry.name:lower()] = entry.fileName
+        end
+    end
+
+    for _, entry in ipairs(Globals.UserModuleManifest) do
+        if entry.name then
+            local claimedBy = claimedNames[entry.name:lower()]
+            if claimedBy and claimedBy ~= entry.fileName then
+                entry.collisionWith = claimedBy
+            else
+                claimedNames[entry.name:lower()] = entry.fileName
+            end
+        end
+    end
+end
+
+--- Returns the manifest entry for a saved user module, matching the declared
+--- name first so a renamed file resolves, then the filename so a file whose
+--- name has become unreadable still resolves.
+---@param moduleName string? Declared _name last seen for the module.
+---@param fileName string? Filename last seen for the module.
+---@return table? entry The matching manifest entry.
+function Core.FindUserModule(moduleName, fileName)
+    for _, entry in ipairs(Globals.UserModuleManifest) do
+        if entry.name and entry.name == moduleName and entry.fileName == fileName then return entry end
+    end
+
+    for _, entry in ipairs(Globals.UserModuleManifest) do
+        if entry.fileName == fileName then return entry end
+    end
+
+    for _, entry in ipairs(Globals.UserModuleManifest) do
+        if entry.name and entry.name == moduleName then return entry end
+    end
+
+    return nil
 end
 
 --- Calls fn via pcall, logging an error with logInfo context on failure.

--- a/utils/globals.lua
+++ b/utils/globals.lua
@@ -69,6 +69,7 @@ Globals.CurrentSongs                  = {}
 Globals.CurrentBlocked                = {}
 Globals.CurrentPetBuffs               = nil
 Globals.CurrentPetBlocked             = nil
+Globals.UserModuleManifest            = {}
 
 Globals.Constants                     = {}
 

--- a/utils/modules.lua
+++ b/utils/modules.lua
@@ -31,6 +31,9 @@ Modules.LoadedUserModules     = {}
 --- Name → message from the most recent failed load attempt.
 Modules.UserModuleLoadErrors  = {}
 
+--- Name → smoothed GiveTime cost in milliseconds.
+Modules.UserModuleFrameTimes  = {}
+
 Modules.UserModuleSyncPending = false
 
 ---@return any
@@ -165,6 +168,7 @@ function Modules:unloadUserModule(moduleName)
     self:unloadModule(moduleName)
     self.LoadedUserModules[moduleName] = nil
     self.UserModuleLoadErrors[moduleName] = nil
+    self.UserModuleFrameTimes[moduleName] = nil
 
     Config:ClearModuleSettings(moduleName)
     Config:UpdateCommandHandlers()
@@ -191,11 +195,21 @@ function Modules:SyncUserModules()
     local Config = require("utils.config")
     local Core = require("utils.core")
 
-    Core.ScanUserModules()
+    local scanned = Core.ScanUserModules()
 
     local savedList = Config:GetSetting('UserModuleList') or {}
     local wantLoaded = {}
     local listChanged = false
+
+    if scanned then
+        for idx = #savedList, 1, -1 do
+            if not Core.FindUserModule(savedList[idx].name, savedList[idx].file) then
+                Logger.log_info("\ayForgetting user module \at%s\ay; its file is no longer in the modules folder.", savedList[idx].name)
+                table.remove(savedList, idx)
+                listChanged = true
+            end
+        end
+    end
 
     for _, listEntry in ipairs(savedList) do
         local manifestEntry = Core.FindUserModule(listEntry.name, listEntry.file)
@@ -290,8 +304,14 @@ function Modules:ExecAll(fn, ...)
             ret[name] = module[fn](module, ...)
 
             if fn == "GiveTime" then
+                local frameTime = (Globals.GetTimeSeconds() * 1000) - startTime
+
                 if self.ModuleList.Perf then
-                    self.ModuleList.Perf:OnFrameExec(name, (Globals.GetTimeSeconds() * 1000) - startTime)
+                    self.ModuleList.Perf:OnFrameExec(name, frameTime)
+                end
+
+                if self.LoadedUserModules[name] then
+                    self.UserModuleFrameTimes[name] = ((self.UserModuleFrameTimes[name] or frameTime) * 0.9) + (frameTime * 0.1)
                 end
             end
         end

--- a/utils/modules.lua
+++ b/utils/modules.lua
@@ -1,11 +1,11 @@
-local mq            = require("mq")
-local Globals       = require("utils.globals")
-local Logger        = require("utils.logger")
+local mq                      = require("mq")
+local Globals                 = require("utils.globals")
+local Logger                  = require("utils.logger")
 
-local Modules       = { _version = '0.1a', _author = 'Derple', }
-Modules.__index     = Modules
+local Modules                 = { _version = '0.1a', _author = 'Derple', }
+Modules.__index               = Modules
 
-Modules.ModuleOrder = {
+Modules.ModuleOrder           = {
     "Class",
     "Movement",
     "Clickies",
@@ -19,10 +19,19 @@ Modules.ModuleOrder = {
     "Perf",
     "Contributors",
     "FAQ",
+    "UserModules",
     "Debug",
 }
 
-Modules.ModuleList  = {}
+Modules.ModuleList            = {}
+
+--- Name → file path for the user modules currently loaded from mq.configDir.
+Modules.LoadedUserModules     = {}
+
+--- Name → message from the most recent failed load attempt.
+Modules.UserModuleLoadErrors  = {}
+
+Modules.UserModuleSyncPending = false
 
 ---@return any
 function Modules:load(lootModule)
@@ -43,6 +52,7 @@ function Modules:load(lootModule)
         Perf         = require("modules.performance"):New(),
         Contributors = require("modules.contributors"):New(),
         FAQ          = require("modules.faq"):New(),
+        UserModules  = require("modules.usermodules"):New(),
         Debug        = require("modules.debug"):New(),
         LootNScoot   = lootModule == "LootNScoot" and require("modules.lootnscoot"):New() or nil,
         SmartLoot    = lootModule == "SmartLoot" and require("modules.smartloot"):New() or nil,
@@ -54,7 +64,25 @@ end
 ---@param moduleName string Name of the module to unload.
 function Modules:unloadModule(moduleName)
     if self.ModuleList[moduleName] ~= nil then
-        self.ModuleList[moduleName]:Shutdown()
+        local module = self.ModuleList[moduleName]
+        local shutdownOk, shutdownError = pcall(function() module:Shutdown() end)
+        if not shutdownOk then
+            Logger.log_error("\ar%s errored during shutdown: %s", moduleName, shutdownError)
+        end
+
+        for _, eventName in ipairs(module._trackedEvents or {}) do
+            mq.unevent(eventName)
+        end
+        for _, slash in ipairs(module._trackedBinds or {}) do
+            mq.unbind(slash)
+        end
+        for _, imguiName in ipairs(module._trackedImGui or {}) do
+            mq.imgui.destroy(imguiName)
+        end
+        for _, dropbox in ipairs(module._trackedActors or {}) do
+            dropbox:unregister()
+        end
+
         self.ModuleList[moduleName] = nil
         for i, v in pairs(self.ModuleOrder) do
             if v == moduleName then
@@ -76,6 +104,133 @@ function Modules:loadModule(moduleName, filePath)
     table.insert(self.ModuleOrder, moduleName)
     Logger.log_info("Load %s", moduleName) -- temp debug text
     Modules:ExecModule(moduleName, "Init")
+end
+
+--- Loads a user module from an absolute file path, appends it to the execution
+--- order and initializes it, rolling back if the file errors.
+---@param moduleName string Declared _name of the module.
+---@param filePath string Absolute path to the user module file.
+---@return boolean success True when the module loaded and initialized.
+function Modules:loadUserModule(moduleName, filePath)
+    local Config = require("utils.config")
+
+    self:unloadUserModule(moduleName)
+
+    local chunk, loadError = loadfile(filePath)
+    if not chunk then
+        Logger.log_error("\arUser module \at%s\ar failed to load: %s", moduleName, loadError)
+        self.UserModuleLoadErrors[moduleName] = loadError
+        return false
+    end
+
+    local success, initError = pcall(function()
+        local instance = chunk():New()
+        if type(instance) ~= "table" then
+            error("New() did not return a module instance.", 0)
+        end
+
+        local claimedBy, claimedSetting = Config:FindConflictingSettingOwner(moduleName, instance.DefaultConfig)
+        if claimedBy then
+            error(string.format("setting '%s' is already owned by the %s module.", claimedSetting, claimedBy), 0)
+        end
+
+        self.ModuleList[moduleName] = instance
+        self.LoadedUserModules[moduleName] = filePath
+        self:ExecModule(moduleName, "Init")
+
+        table.insert(self.ModuleOrder, moduleName)
+        Config:UpdateCommandHandlers()
+    end)
+
+    if not success then
+        Logger.log_error("\arUser module \at%s\ar failed to initialize: %s", moduleName, initError)
+        self:unloadUserModule(moduleName)
+        self.UserModuleLoadErrors[moduleName] = initError
+        return false
+    end
+
+    self.UserModuleLoadErrors[moduleName] = nil
+    Logger.log_info("\agLoaded user module \at%s", moduleName)
+    return true
+end
+
+--- Shuts down a loaded user module and drops its in-memory settings
+--- registration; persisted values are left in the database.
+---@param moduleName string Declared _name of the module.
+function Modules:unloadUserModule(moduleName)
+    if not self.LoadedUserModules[moduleName] then return end
+
+    local Config = require("utils.config")
+
+    self:unloadModule(moduleName)
+    self.LoadedUserModules[moduleName] = nil
+    self.UserModuleLoadErrors[moduleName] = nil
+
+    Config:ClearModuleSettings(moduleName)
+    Config:UpdateCommandHandlers()
+end
+
+--- Flags that the loaded user modules need reconciling against the saved list.
+--- Callers on the ImGui render thread must use this rather than syncing inline.
+function Modules:RequestUserModuleSync()
+    self.UserModuleSyncPending = true
+end
+
+--- Runs a pending sync. Called from the main loop, outside any ModuleOrder walk.
+function Modules:ProcessUserModuleSync()
+    if not self.UserModuleSyncPending then return end
+
+    self.UserModuleSyncPending = false
+    self:SyncUserModules()
+end
+
+--- Rescans the user modules folder and brings the loaded user modules in line
+--- with the saved list, unloading what is no longer enabled and loading what is.
+--- Safe to call repeatedly; already-loaded modules are left running.
+function Modules:SyncUserModules()
+    local Config = require("utils.config")
+    local Core = require("utils.core")
+
+    Core.ScanUserModules()
+
+    local savedList = Config:GetSetting('UserModuleList') or {}
+    local wantLoaded = {}
+    local listChanged = false
+
+    for _, listEntry in ipairs(savedList) do
+        local manifestEntry = Core.FindUserModule(listEntry.name, listEntry.file)
+        if manifestEntry and manifestEntry.name and not manifestEntry.error and not manifestEntry.collisionWith then
+            if listEntry.name ~= manifestEntry.name or listEntry.file ~= manifestEntry.fileName then
+                listEntry.name = manifestEntry.name
+                listEntry.file = manifestEntry.fileName
+                listChanged = true
+            end
+
+            if listEntry.enabled then
+                wantLoaded[manifestEntry.name] = manifestEntry.filePath
+            end
+        end
+    end
+
+    local staleModules = {}
+    for moduleName, filePath in pairs(self.LoadedUserModules) do
+        if wantLoaded[moduleName] ~= filePath then
+            table.insert(staleModules, moduleName)
+        end
+    end
+    for _, moduleName in ipairs(staleModules) do
+        self:unloadUserModule(moduleName)
+    end
+
+    for _, listEntry in ipairs(savedList) do
+        if listEntry.enabled and wantLoaded[listEntry.name] and not self.LoadedUserModules[listEntry.name] then
+            self:loadUserModule(listEntry.name, wantLoaded[listEntry.name])
+        end
+    end
+
+    if listChanged then
+        Config:SetSetting('UserModuleList', savedList)
+    end
 end
 
 --- Returns the raw ModuleList table (name → module instance).


### PR DESCRIPTION
* Major Update: User Modules

* Added support for user modules, which run in the rgmercs loop like other modules (such as class, or clickies), and can execute code while tapping in to rgmercs state.
* * Please refer to \docs\user_modules.md.
* * An example file is included in your mq\config\rgmercs\modules directory.
* * Modules can be enabled or disabled with /rgl usermodule <name> <on|off>.

Table-valued settings no longer share their default table

* Settings with a table default handed out the default table itself rather than a copy, so editing a list wrote into the default.
* A persona swap to a class with no saved row for that setting then started from the polluted default instead of an empty list.
* Affects the list settings in Charm, Clickies, Map, Mez and Pull.

