### PR TITLE
DB Management - Reset to Default is now allowed for an active peer

### DIFF
--- a/tests/db_management_test.lua
+++ b/tests/db_management_test.lua
@@ -6,9 +6,10 @@
 --
 -- It operates on sentinel characters on a fake server ("rgtestsrv") inside the live config DB,
 -- exercises the real CopySettings / ResetSettings / DeleteSettings / ClearList / DBManagement.RequestReload
--- and the running-peer reset/delete guards, then deletes the sentinel rows/characters. A handful of
--- functions (ClassLoader.reloadConfig, Comms.SendMessage / GetPeerHeartbeat / IsCharRunning, Config.Db.deleteModule, and briefly
--- Globals.CurLoadedChar/Server/Class) are swapped to observe behavior and restored afterward.
+-- and the running-peer delete guard, then deletes the sentinel rows/characters. A handful of
+-- functions (ClassLoader.reloadConfig, Comms.SendMessage / GetPeerHeartbeat / IsCharRunning,
+-- Config.Db.deleteModule) are swapped to observe behavior and restored afterward; the Globals
+-- char/server/class are deliberately never patched -- see the NOTE above the snapshot table.
 -- If anything leaks and mercs misbehaves, `/lua run rgmercs` to reload. Output goes straight to
 -- the console via printf (not the RGMercs logger), so it shows regardless of log level.
 
@@ -161,6 +162,18 @@ function M.RunAll()
     local rec = {}
     local savedPullDeny = Config:GetSetting('PullDenyListShared')
 
+    -- The send recorder only flags the actual "ReloadConfig" event and delegates everything else to the
+    -- real function -- the render loop interleaves with debug-window execution and would otherwise both
+    -- trip the recorder and get nil where it expects a value.
+    local function makeSendRecorder(onReload)
+        return function(peer, mod, evt, ...)
+            if evt == "ReloadConfig" then
+                onReload(peer, mod, evt); return
+            end
+            return sv.SendMessage(peer, mod, evt, ...)
+        end
+    end
+
     local ranOk, runErr = pcall(function()
         -- 1) Copy "All Modules"
         wipe("a", CLS); wipe("b", CLS)
@@ -208,25 +221,36 @@ function M.RunAll()
         check("Reset single: target module cleared", nKeys(getM("h", CLS, testMods[1])) == 0)
         if testMods[2] then check("Reset single: other module NOT cleared", nKeys(getM("h", CLS, testMods[2])) > 0) end
 
-        -- 5a) Reset: refuses while target is "running" (asserts the refusal itself, since surviving rows
-        -- alone would not distinguish it from the other bails)
+        -- 5a) Reset: a running peer is cleared in place and told to re-read. Stubbing the heartbeat
+        -- rather than IsCharRunning leaves the reload's own send gate to decide, which is the only
+        -- running check left on this path. The stub stays up through 5b, which needs the same peer.
         wipe("h", CLS)
         setM("h", CLS, testMods[1], buildSeed(Config.moduleDefaultSettings[testMods[1]]))
+        local runningKey = "h (" .. SRV:sub(1, 1):upper() .. SRV:sub(2) .. ")"
         ---@diagnostic disable-next-line: duplicate-set-field
-        Comms.IsCharRunning = function() return true end
-        local guarded = DBManagement.ResetSettings("h", SRV, CLS, "All Modules")
-        Comms.IsCharRunning = sv.IsCharRunning
-        check("Reset guard: reports refusal", guarded.ok == false and guarded.refusedRunning == true,
-            string.format("ok=%s refusedRunning=%s", tostring(guarded.ok), tostring(guarded.refusedRunning)))
-        check("Reset guard: rows intact", nKeys(getM("h", CLS, testMods[1])) > 0)
+        Comms.GetPeerHeartbeat = function(key)
+            if key == runningKey then return { Data = { Class = CLS, }, } end
+            return sv.GetPeerHeartbeat(key)
+        end
+        Comms.SendMessage = makeSendRecorder(function(peer) rec.sentPeer = peer end)
+        local running = DBManagement.ResetSettings("h", SRV, CLS, "All Modules")
+        Comms.SendMessage = sv.SendMessage
+        check("Reset running peer: proceeds", running.ok == true, string.format("ok=%s", tostring(running.ok)))
+        check("Reset running peer: rows cleared", nKeys(getM("h", CLS, testMods[1])) == 0,
+            string.format("left=%d", nKeys(getM("h", CLS, testMods[1]))))
+        check("Reset running peer: peer told to reload", rec.sentPeer == runningKey,
+            string.format("got peer=%s (expected %s)", tostring(rec.sentPeer), runningKey))
 
         -- 5b) Reset: a busy db is reported to the caller rather than reloading stale settings
+        rec.sentPeer = nil
         ---@diagnostic disable-next-line: duplicate-set-field
         Config.Db.deleteModule = function(_, _, _, _, _) return false end
+        Comms.SendMessage = makeSendRecorder(function(peer) rec.sentPeer = peer end)
         local busy = DBManagement.ResetSettings("h", SRV, CLS, "All Modules")
         Config.Db.deleteModule = sv.deleteModule
-        check("Reset busy: reports the busy db, not another bail", busy.ok == false and busy.refusedRunning ~= true,
-            string.format("ok=%s refusedRunning=%s", tostring(busy.ok), tostring(busy.refusedRunning)))
+        Comms.SendMessage, Comms.GetPeerHeartbeat = sv.SendMessage, sv.GetPeerHeartbeat
+        check("Reset busy: reports the busy db", busy.ok == false, string.format("ok=%s", tostring(busy.ok)))
+        check("Reset busy: no reload requested", rec.sentPeer == nil, string.format("sent to %s", tostring(rec.sentPeer)))
 
         -- 6) Delete: refuses while target is "running", then succeeds
         wipe("i", CLS)
@@ -267,20 +291,8 @@ function M.RunAll()
 
         -- The reload tests call DBManagement.RequestReload directly (no DB writes, no Globals patching).
         -- For the "local current" path we pass the real current char/server/class so Comms.IsLocalCurrent
-        -- is true without touching anything. The send recorder only flags the actual "ReloadConfig" event
-        -- and delegates everything else to the real function -- the render loop interleaves with
-        -- debug-window execution and would otherwise both trip the recorder and get nil where it expects a value.
-        -- ClassLoader.reloadConfig is stubbed outright: really reloading here would re-register every
-        -- module's settings underneath the run.
-
-        local function makeSendRecorder(onReload)
-            return function(peer, mod, evt, ...)
-                if evt == "ReloadConfig" then
-                    onReload(peer, mod, evt); return
-                end
-                return sv.SendMessage(peer, mod, evt, ...)
-            end
-        end
+        -- is true without touching anything. ClassLoader.reloadConfig is stubbed outright: really
+        -- reloading here would re-register every module's settings underneath the run.
 
         -- 7) Reload: local current -> ClassLoader.reloadConfig
         rec.reloadHit = false

--- a/ui/options.lua
+++ b/ui/options.lua
@@ -742,10 +742,9 @@ function OptionsUI:RenderDBManagement()
     if not noChars then
         fromName, fromServer = self.dbChars[self.dbFromIdx]:match('^(.+) %((.+)%)$')
     end
-    local fromIsRunning     = fromName and Comms.IsCharRunning(fromName, fromServer, fromClass) or false
-    local fromIsRunningPeer = fromIsRunning and not Comms.IsLocalCurrent(fromName, fromServer, fromClass)
-    local canDelete         = not noChars and not fromIsRunning
-    local canReset          = not noChars and not fromIsRunningPeer
+    local fromIsRunning = fromName and Comms.IsCharRunning(fromName, fromServer, fromClass) or false
+    local canDelete     = not noChars and not fromIsRunning
+    local canReset      = not noChars
 
     if ImGui.BeginTable("##dbmgmt", 4, ImGuiTableFlags.SizingFixedFit) then
         ImGui.TableSetupColumn("label", ImGuiTableColumnFlags.WidthFixed, 80)
@@ -795,11 +794,6 @@ function OptionsUI:RenderDBManagement()
             self.dbOpenResetPopup = true
         end
         if not canReset then ImGui.EndDisabled() end
-        if fromIsRunningPeer and not noChars then
-            if ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled) then
-                ImGui.SetTooltip("Cannot reset: target character is currently running RGMercs.")
-            end
-        end
         ImGui.SameLine()
         if not canDelete then ImGui.BeginDisabled() end
         if ImGui.Button(Icons.FA_TRASH .. " Delete from Database##dbdelete") then
@@ -1011,8 +1005,10 @@ function OptionsUI:ResetSettings(charLabels, fromIdx, fromClass, moduleName)
     local result = DBManagement.ResetSettings(fromName, fromServer, fromClass, moduleName)
     if not result.ok then return end
 
-    self.dbChars       = nil
-    self.dbFromClasses = nil
+    if not Comms.IsCharRunning(fromName, fromServer, fromClass) then
+        self.dbChars       = nil
+        self.dbFromClasses = nil
+    end
 
     self:AddDBToast(result.toastMessage, Globals.Constants.Colors.Green)
 end

--- a/utils/config.lua
+++ b/utils/config.lua
@@ -4567,7 +4567,7 @@ function Config:DbConsistencyCheck()
         moduleCount = moduleCount + 1
         for setting, _ in pairs(defaults) do
             local value   = self:GetSetting(setting)
-            local dbValue = Config.Db:getValue(Globals.CurServer, Globals.CurLoadedChar, Globals.CurLoadedClass, module, setting)
+            local dbValue = self:SettingDbRead(module, setting)
             if type(dbValue) == "table" and type(value) == "table" then
                 if not Tables.AreTablesEqual(dbValue, value) then
                     Logger.log_error("\arInconsistency found for %s \aw- \atDB Value\aw: \ag%s\aw, \atIn-Memory Value: \ag%s\aw",

--- a/utils/config_db.lua
+++ b/utils/config_db.lua
@@ -1139,10 +1139,15 @@ function DB:_fetchModule(serverName, charName, charClass, module)
     stmt:bind(2, charName)
     stmt:bind(3, charClass)
     stmt:bind(4, module)
+    local fetched = {}
     for row in stmt:nrows() do
-        self:_cacheSet(serverName, charName, charClass, module, row.key, deserialize(row.key, row.value, row.value_type))
+        fetched[row.key] = deserialize(row.key, row.value, row.value_type)
     end
     stmt:finalize()
+    self:_cacheDelModule(serverName, charName, charClass, module)
+    for key, value in pairs(fetched) do
+        self:_cacheSet(serverName, charName, charClass, module, key, value)
+    end
 end
 
 function DB:_fetchServerValue(serverName, module, key)
@@ -1178,10 +1183,15 @@ function DB:_fetchServerModule(serverName, module)
     if not stmt then return end
     stmt:bind(1, serverName)
     stmt:bind(2, module)
+    local fetched = {}
     for row in stmt:nrows() do
-        self:_serverCacheSet(serverName, module, row.key, deserialize(row.key, row.value, row.value_type))
+        fetched[row.key] = deserialize(row.key, row.value, row.value_type)
     end
     stmt:finalize()
+    self:_serverCacheDelModule(serverName, module)
+    for key, value in pairs(fetched) do
+        self:_serverCacheSet(serverName, module, key, value)
+    end
 end
 
 ---Poll data_version. Call from your main loop tick alongside flushQueue().

--- a/utils/db_management.lua
+++ b/utils/db_management.lua
@@ -82,22 +82,16 @@ function DBManagement.CopySettings(fromName, fromServer, fromClass, toName, toSe
 end
 
 --- Clears saved module settings for the given char/server/class so the target rebuilds
---- its own defaults on next load. Refuses if the target is a peer currently running
---- RGMercs; reloads in place when the target is the local character.
+--- its own defaults, and has it pick them up in place when it is running that class.
 --- @param charName string
 --- @param server string
 --- @param class string
 --- @param moduleName string Module name, or "All Modules".
---- @return table result { ok, refusedRunning, toastMessage }
+--- @return table result { ok, toastMessage }
 function DBManagement.ResetSettings(charName, server, class, moduleName)
     if not charName then return { ok = false, } end
 
     local label = string.format("%s (%s)", charName, server)
-
-    if not Comms.IsLocalCurrent(charName, server, class) and Comms.IsCharRunning(charName, server, class) then
-        Logger.log_error("DB Management: refusing to reset %s [%s] -- target is currently running RGMercs", label, class)
-        return { ok = false, refusedRunning = true, }
-    end
 
     local toReset = {}
     if moduleName == "All Modules" then
@@ -136,7 +130,7 @@ end
 --- @param charName string
 --- @param server string
 --- @param class string
---- @return table result { ok, refusedRunning, toastMessage }
+--- @return table result { ok, toastMessage }
 function DBManagement.DeleteSettings(charName, server, class)
     if not charName then return { ok = false, } end
 
@@ -145,7 +139,7 @@ function DBManagement.DeleteSettings(charName, server, class)
     -- Don't delete an active character's settings -- they'd save them back.
     if Comms.IsCharRunning(charName, server, class) then
         Logger.log_error("DB Management: refusing to delete %s [%s] -- target is currently running RGMercs", label, class)
-        return { ok = false, refusedRunning = true, }
+        return { ok = false, }
     end
 
     if not Config.Db:deleteCharacterClass(server, charName, class) then


### PR DESCRIPTION
Previously, this functionality was grayed out/disabled, the user had to stop mercs on the toon they wanted to reset to default.